### PR TITLE
「編集内容を保存しました」表示のレイヤーがおかしいのを修正

### DIFF
--- a/lib/components/edit_item_info_popup/edit_item_info_form.dart
+++ b/lib/components/edit_item_info_popup/edit_item_info_form.dart
@@ -3,13 +3,11 @@ import 'package:snappy/importer.dart';
 
 class EditItemInfoForm extends StatefulWidget {
   final ItemData item;
-  final VoidCallback onSubmit;
   final Future<void> Function() onRefresh;
 
   const EditItemInfoForm({
     super.key,
     required this.item,
-    required this.onSubmit,
     required this.onRefresh,
   });
 
@@ -95,16 +93,13 @@ class _EditItemInfoFormState extends State<EditItemInfoForm> {
       print('After update title: ${updatedScreenshot?.title}');
 
       // 編集完了後にDBの最新データを再取得
-      if (widget.onRefresh != null) {
-        print('Refreshing data...');
-        await widget.onRefresh!();
-      }
+      print('Refreshing data...');
+      await widget.onRefresh();
 
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(const SnackBar(content: Text('編集内容を保存しました')));
+        Navigator.of(context).pop(true);
       }
-      widget.onSubmit();
+      // widget.onSubmit();
     }
   }
 

--- a/lib/components/edit_item_info_popup/edit_item_info_popup.dart
+++ b/lib/components/edit_item_info_popup/edit_item_info_popup.dart
@@ -1,14 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:snappy/importer.dart'; // ご自身のプロジェクトのパスに合わせてください
+import 'package:snappy/importer.dart';
 
-// グローバルな関数として定義
-Future<void> showEditItemPopup(
+Future<bool?> showEditItemPopup(
   BuildContext context, {
   required ItemData item,
-  VoidCallback? onEdit,
-}) async {
-  // showModalBottomSheetのロジックを完全にここにカプセル化する
-  await showModalBottomSheet<void>(
+  required Future<void> Function() onRefresh,
+}) {
+  return showModalBottomSheet<bool>(
     backgroundColor: Colors.white,
     context: context,
     isScrollControlled: true,
@@ -20,18 +18,9 @@ Future<void> showEditItemPopup(
         bottom: MediaQuery.of(modalContext).viewInsets.bottom + 24.0,
       ),
       child: SingleChildScrollView(
-        child: ConstrainedBox(
-          constraints: BoxConstraints(
-            minHeight: MediaQuery.of(context).size.height * 0.5,
-          ),
-          child: EditItemInfoForm(
-            item: item,
-            onSubmit: () {
-              onEdit?.call();
-              Navigator.of(modalContext).pop();
-            },
-            onRefresh: () async {},
-          ),
+        child: EditItemInfoForm(
+          item: item,
+          onRefresh: onRefresh,
         ),
       ),
     ),

--- a/lib/components/items_view/item_card.dart
+++ b/lib/components/items_view/item_card.dart
@@ -9,7 +9,7 @@ class ItemCard extends StatelessWidget {
   final VoidCallback? onTap;
   final VoidCallback? onLongPress;
   final Uint8List? thumbnailBytes;
-  final VoidCallback? onEdit;
+  final Future<void> Function()? onEdit;
 
   const ItemCard({
     super.key,
@@ -74,12 +74,19 @@ class ItemCard extends StatelessWidget {
                     borderRadius: BorderRadius.circular(8),
                     child: IconButton(
                       icon: const Icon(Icons.edit, color: Colors.white),
-                      onPressed: () {
-                        showEditItemPopup(
+                      onPressed: () async {
+                        if (onEdit == null) return;
+                        final bool? success = await showEditItemPopup(
                           context,
                           item: item,
-                          onEdit: onEdit,
+                          onRefresh: onEdit!,
                         );
+                        if (!context.mounted) return;
+                        if (success == true) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(content: Text('編集内容を保存しました')),
+                          );
+                        }
                       },
                       tooltip: 'Edit',
                       splashRadius: 20,

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -319,45 +319,38 @@ class _HomeState extends State<Home> with RouteAware {
     );
   }
 
-  void _showPopup(ItemData item) {
+  void _showPopup(ItemData item) async {
     final dbData = _isarScreenshotMap[item.id];
-    showDialog(
+    final bool? success = await showDialog<bool>(
       context: context,
-      barrierColor: Colors.black.withOpacity(0.7), // 背景を半透明黒にして暗くする
-      builder: (context) => Dialog(
+      barrierColor: Colors.black.withOpacity(0.7),
+      builder: (dialogContext) => Dialog(
         backgroundColor: Colors.transparent,
-        insetPadding: const EdgeInsets.symmetric(horizontal: 40), // 横の余白で幅調整
+        insetPadding: const EdgeInsets.symmetric(horizontal: 40),
         child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 400), // 最大幅400pxに制限
+          constraints: const BoxConstraints(maxWidth: 400),
           child: PopupContainer(
             assetEntity: item.assetEntity!,
             title: dbData?.title,
             location: dbData?.location,
-            // onPressedEdit: () {
-            //   showEditItemPopup(context, item: item, onEdit: refreshData);
-            // },
             onPressedEdit: () async {
-              Navigator.of(context).pop();
-
-              final bool? success = await showEditItemPopup(
+              final bool? editSuccess = await showEditItemPopup(
                 context,
                 item: item,
-                onRefresh: refreshData, // onRefreshとしてrefreshDataを渡す
+                onRefresh: refreshData,
               );
 
-              if (success == true && mounted) {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('編集内容を保存しました')),
-                );
+              if (editSuccess == true) {
+                Navigator.of(dialogContext).pop(true);
               }
             },
             onPressedDelete: () async {
               DeleteItemService.deleteScreenshotWithAuth(
-                context: context,
+                context: dialogContext, // dialogContextを使う
                 assetEntity: item.assetEntity!,
                 assetId: item.id,
                 onSuccess: () {
-                  Navigator.of(context).pop();
+                  Navigator.of(dialogContext).pop();
                 },
                 onError: null,
               );
@@ -366,6 +359,12 @@ class _HomeState extends State<Home> with RouteAware {
         ),
       ),
     );
+    // 編集が成功した場合にSnackBarを表示
+    if (success == true && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('編集内容を保存しました')),
+      );
+    }
   }
 
   Widget _buildSelectionPanel() {
@@ -446,9 +445,9 @@ class _HomeState extends State<Home> with RouteAware {
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  Text(
+                  const Text(
                     '画像を読み込み中...',
-                    style: const TextStyle(
+                    style: TextStyle(
                       color: Colors.black,
                       fontSize: 16,
                       fontWeight: FontWeight.bold,

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -333,8 +333,23 @@ class _HomeState extends State<Home> with RouteAware {
             assetEntity: item.assetEntity!,
             title: dbData?.title,
             location: dbData?.location,
-            onPressedEdit: () {
-              showEditItemPopup(context, item: item, onEdit: refreshData);
+            // onPressedEdit: () {
+            //   showEditItemPopup(context, item: item, onEdit: refreshData);
+            // },
+            onPressedEdit: () async {
+              Navigator.of(context).pop();
+
+              final bool? success = await showEditItemPopup(
+                context,
+                item: item,
+                onRefresh: refreshData, // onRefreshとしてrefreshDataを渡す
+              );
+
+              if (success == true && mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('編集内容を保存しました')),
+                );
+              }
             },
             onPressedDelete: () async {
               DeleteItemService.deleteScreenshotWithAuth(


### PR DESCRIPTION
PopupContainerの上に表示させてみたところ不自然だと感じたので、
編集ポップアップで「確定」ボタンを押すと、PopupContainerごと閉じるようにしました
こっちの方が自然じゃないかなーと思ったんですが........どうでしょう。ご意見ください

https://github.com/user-attachments/assets/ffa12bdc-a14e-4f81-a6e6-3a1fee73415a

もともとの動作
https://github.com/user-attachments/assets/c8a0666a-a5ab-4590-944e-fcc638c30753

