### PR TITLE
fix: improve popup dialog with close button and barrier dismissible

### DIFF
--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -407,31 +407,57 @@ class _HomeState extends State<Home> with RouteAware {
   Future<void> _showPopup(ItemData item) async {
     final success = await showDialog<bool>(
       context: context,
+      barrierDismissible: true,
       barrierColor: Colors.black.withOpacity(0.7),
       builder: (ctx) => Dialog(
         backgroundColor: Colors.transparent,
         insetPadding: const EdgeInsets.symmetric(horizontal: 40),
         child: ConstrainedBox(
           constraints: const BoxConstraints(maxWidth: 400),
-          child: PopupContainer(
-            item: item,
-            onPressedEdit: () async {
-              final edited = await showEditItemPopup(
-                context,
-                item: item,
-                onRefresh: refreshData,
-              );
-              if (edited == true) Navigator.of(ctx).pop(true);
-            },
-            onPressedDelete: () async {
-              await DeleteItemService.deleteScreenshotWithAuth(
-                context: ctx,
-                assetEntity: item.assetEntity!,
-                assetId: item.id,
-                onSuccess: () => Navigator.of(ctx).pop(),
-                onError: null,
-              );
-            },
+          child: Stack(
+            clipBehavior: Clip.none,
+            children: [
+              Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  PopupContainer(
+                    item: item,
+                    onPressedEdit: () async {
+                      final edited = await showEditItemPopup(
+                        context,
+                        item: item,
+                        onRefresh: refreshData,
+                      );
+                      if (edited == true) Navigator.of(ctx).pop(true);
+                    },
+                    onPressedDelete: () async {
+                      await DeleteItemService.deleteScreenshotWithAuth(
+                        context: ctx,
+                        assetEntity: item.assetEntity!,
+                        assetId: item.id,
+                        onSuccess: () => Navigator.of(ctx).pop(),
+                        onError: null,
+                      );
+                    },
+                  ),
+                ],
+              ),
+
+              // 右上に閉じるボタン
+              Positioned(
+                top: -30,
+                right: 30,
+                child: Material(
+                  color: Colors.white.withOpacity(0.9),
+                  shape: const CircleBorder(),
+                  child: IconButton(
+                    icon: const Icon(Icons.close, color: Colors.black),
+                    onPressed: () => Navigator.of(ctx).pop(),
+                    tooltip: '閉じる',
+                  ),
+                ),
+              ),
+            ],
           ),
         ),
       ),


### PR DESCRIPTION
バツボタンを追加

[
<img width="312" height="613" alt="スクリーンショット 2025-09-29 104357" src="https://github.com/user-attachments/assets/ae17b0cb-d625-474a-a8f6-9767e1fade00" />
](url)